### PR TITLE
adding UNI/USDC PYTH incentives

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -689,8 +689,8 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
   },
   // UNI/USDC Mainnet 200k PYTH 07/31/2024-10/01/2024 12pm EST
   {
-    start: 1722441600n,
-    end: 1727798400n,
+    start: 1723046400n,
+    end: 1728316800n,
     fundsSender: "0xE64fD4d6f8128A27365Bee615eC9eD33979c782C",
     urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
     tokenAddress: "0xeFc0CED4B3D536103e76a1c4c74F0385C8F4Bdd3",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -687,10 +687,10 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
-  // UNI/USDC Mainnet 200k PYTH 07/26/2024-09/26/2024 12pm EST
+  // UNI/USDC Mainnet 200k PYTH 07/31/2024-10/01/2024 12pm EST
   {
-    start: 1722009600n,
-    end: 1727366400n,
+    start: 1722441600n,
+    end: 1727798400n,
     fundsSender: "0xE64fD4d6f8128A27365Bee615eC9eD33979c782C",
     urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
     tokenAddress: "0xeFc0CED4B3D536103e76a1c4c74F0385C8F4Bdd3",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -687,4 +687,19 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
+  // UNI/USDC Mainnet 200k PYTH 07/26/2024-09/26/2024 12pm EST
+  {
+    start: 1722009600n,
+    end: 1727366400n,
+    fundsSender: "0xE64fD4d6f8128A27365Bee615eC9eD33979c782C",
+    urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
+    tokenAddress: "0xeFc0CED4B3D536103e76a1c4c74F0385C8F4Bdd3",
+    marketId: "0x718af3af39b183758849486340b69466e3e89b84b7884188323416621ee91cb7",
+    rewardAmount: {
+      supply: parseUnits("200000", 6),
+      borrow: 0n,
+      collateral: 0n,
+    },
+    chainId: ChainId.MAINNET,
+  },
 ];


### PR DESCRIPTION
## Context
Adding PYTH incentives to UNI/USDC Market. 
- 200k PYTH 07/26/2024-09/26/2024 12pm EST
