### PR TITLE
feat: Oval OEV rewards pufETH/USDC

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -702,9 +702,9 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
-  // pufETH / USDC Mainnet 0.094 WETH 08/07/2024 09/07/2024 1pm GMT
+  // pufETH / USDC Mainnet 0.094 WETH 08/09/2024 09/07/2024 1pm GMT
   {
-    start: 1723035600n,
+    start: 1723226400n,
     end: 1725714000n,
     fundsSender: "0x9Cc5b1bc0E1970D44B5Adc7ba51d76a5DD375434",
     urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -719,7 +719,7 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
   },
   // pufETH / USDC Mainnet 0.094 WETH 08/09/2024 09/07/2024 1pm GMT
   {
-    start: 1723226400n,
+    start: 1723208400n,
     end: 1725714000n,
     fundsSender: "0x9Cc5b1bc0E1970D44B5Adc7ba51d76a5DD375434",
     urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -702,4 +702,19 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
+  // pufETH / USDC Mainnet 0.094 WETH 08/07/2024 09/07/2024 1pm GMT
+  {
+    start: 1723035600n,
+    end: 1725714000n,
+    fundsSender: "0x9Cc5b1bc0E1970D44B5Adc7ba51d76a5DD375434",
+    urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    marketId: "0x7e9c708876fa3816c46aeb08937b51aa0461c2af3865ecb306433db8a80b1d1b",
+    rewardAmount: {
+      supply: 94597806657332024,
+      borrow: 0n,
+      collateral: 0n,
+    },
+    chainId: ChainId.MAINNET,
+  },
 ];

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -711,7 +711,7 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     marketId: "0x7e9c708876fa3816c46aeb08937b51aa0461c2af3865ecb306433db8a80b1d1b",
     rewardAmount: {
-      supply: 94597806657332024,
+      supply: 94597806657332024n,
       borrow: 0n,
       collateral: 0n,
     },


### PR DESCRIPTION
## Context
Oval OEV from liquidations distributed to Morpho liquidity providers for the pufETH/USDC Morpho market. [Morpho market page](https://risk.morpho.org/market?id=0x7e9c708876fa3816c46aeb08937b51aa0461c2af3865ecb306433db8a80b1d1b).