### PR TITLE
feat: update moonwell rewards with EURC vault

### DIFF
--- a/src/vault-programs.ts
+++ b/src/vault-programs.ts
@@ -75,7 +75,18 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     amount: parseUnits("8330000", 18),
     chainId: ChainId.BASE,
   },
-  // Moonwell Flagship USDC 12,500,000 WELL
+  // Moonwell Flagship EURC 1,500,000 WELL
+  {
+    start: 1723903200n,
+    end: 1729087200n,
+    fundsSender: "0x74Cbb1E8B68dDD13B28684ECA202a351afD45EAa",
+    urdAddress: "0x9e3380f8B29E8f85cA19EFFA80Fb41149417D943",
+    tokenAddress: "0xA88594D404727625A9437C3f886C7643872296AE",
+    vault: "0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026",
+    amount: parseUnits("1500000", 18),
+    chainId: ChainId.BASE,
+  },
+  // Moonwell Flagship USDC 10,000,000 WELL
   {
     start: 1729087200n,
     end: 1734271200n,
@@ -86,7 +97,7 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     amount: parseUnits("12500000", 18),
     chainId: ChainId.BASE,
   },
-  // Moonwell Flagship ETH 12,500,000 WELL
+  // Moonwell Flagship ETH 10,000,000 WELL
   {
     start: 1729087200n,
     end: 1734271200n,
@@ -95,6 +106,17 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     tokenAddress: "0xA88594D404727625A9437C3f886C7643872296AE",
     vault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1",
     amount: parseUnits("12500000", 18),
+    chainId: ChainId.BASE,
+  },
+  // Moonwell Flagship EURC 3,500,000 WELL
+  {
+    start: 1729087200n,
+    end: 1734271200n,
+    fundsSender: "0x74Cbb1E8B68dDD13B28684ECA202a351afD45EAa",
+    urdAddress: "0x9e3380f8B29E8f85cA19EFFA80Fb41149417D943",
+    tokenAddress: "0xA88594D404727625A9437C3f886C7643872296AE",
+    vault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1",
+    amount: parseUnits("3500000", 18),
     chainId: ChainId.BASE,
   },
   // LlamaRisk crvUSD Vault - 47,777 CRV over 1 month

--- a/src/vault-programs.ts
+++ b/src/vault-programs.ts
@@ -77,7 +77,7 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
   },
   // Moonwell Flagship EURC 1,500,000 WELL
   {
-    start: 1723903200n,
+    start: 1726758000n,
     end: 1729087200n,
     fundsSender: "0x74Cbb1E8B68dDD13B28684ECA202a351afD45EAa",
     urdAddress: "0x9e3380f8B29E8f85cA19EFFA80Fb41149417D943",
@@ -94,7 +94,7 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     urdAddress: "0x9e3380f8B29E8f85cA19EFFA80Fb41149417D943",
     tokenAddress: "0xA88594D404727625A9437C3f886C7643872296AE",
     vault: "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca",
-    amount: parseUnits("12500000", 18),
+    amount: parseUnits("10000000", 18),
     chainId: ChainId.BASE,
   },
   // Moonwell Flagship ETH 10,000,000 WELL
@@ -105,7 +105,7 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     urdAddress: "0x9e3380f8B29E8f85cA19EFFA80Fb41149417D943",
     tokenAddress: "0xA88594D404727625A9437C3f886C7643872296AE",
     vault: "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1",
-    amount: parseUnits("12500000", 18),
+    amount: parseUnits("10000000", 18),
     chainId: ChainId.BASE,
   },
   // Moonwell Flagship EURC 3,500,000 WELL


### PR DESCRIPTION
## Context

- Distribute 1.5m WELL tokens starting from thursday to end of current epoch on EURC vault
- Amount is taken from the last epochs that should have been distributed to USDC and WETH vaults
- Distribute 2.5m WELL on EURC vault over the last epoch
- Update the other rewards distrib by subtracting the removed rewards (25m - 5m) / 2 = 10m
