### PR TITLE
Add cbBTC/USDC 10K market reward program on Mainnet

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1034,7 +1034,7 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
   },
   // cbBTC/EURC 12,500 EURC 09/24/2024 11/08/2024 1pm EST
   {
-    start: 1727197200n,
+    start: 1727197200n, 
     end: 1731088800n,
     fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
     urdAddress: "0x5400dBb270c956E8985184335A1C62AcA6Ce1333",
@@ -1046,5 +1046,20 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
       collateral: 0n,
     },
     chainId: ChainId.BASE,
+  },
+  // cbBTC/USDC 10,000 USDC on Mainnet 09/26/2024 10/03/2024 1pm EST
+  {
+    start: 1727384400n,
+    end: 1727989200n,
+    fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
+    urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
+    tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    marketId: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64",
+    rewardAmount: {
+      supply: parseUnits("10000", 6),
+      borrow: 0n,
+      collateral: 0n,
+    },
+    chainId: ChainId.MAINNET,
   },
 ];

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1034,7 +1034,7 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
   },
   // cbBTC/EURC 12,500 EURC 09/24/2024 11/08/2024 1pm EST
   {
-    start: 1727197200n, 
+    start: 1727197200n,
     end: 1731088800n,
     fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
     urdAddress: "0x5400dBb270c956E8985184335A1C62AcA6Ce1333",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1049,8 +1049,8 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
   },
   // cbBTC/USDC 10,000 USDC on Mainnet 09/26/2024 10/03/2024 1pm EST
   {
-    start: 1727384400n,
-    end: 1727989200n,
+    start: 1727370000n,
+    end: 1727974800n,
     fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
     urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
     tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1056,8 +1056,8 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     marketId: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64",
     rewardAmount: {
-      supply: parseUnits("10000", 6),
-      borrow: 0n,
+      supply: parseUnits("2500", 6),
+      borrow:  parseUnits("7500", 6),
       collateral: 0n,
     },
     chainId: ChainId.MAINNET,


### PR DESCRIPTION
Add a new market reward program for the cbBTC/USDC market on Mainnet. This program will run from September 26, 2024, to October 3, 2024, at 1pm EST. The reward amount for this program is 10,000 USDC to be split in a 75:25 ratio for the borrow and supply sides respectively.

## Context

Please, provide here any context that could help us to validate the Reward Program(s).

## Merge conditions checklist

- [ ] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [x] Send funds to the URD; the PR will only be merged after the funds have been received.
tx: https://etherscan.io/tx/0x10b605ea4214371ae83bf613e2054cb3365f2c23dcf00f52400c6bb64c2df920

**Important**: If the delay between the PR creation and the start of the Program(s) is less than one week, or if we do not see any funds sent to the URD, the PR will not be merged, and the Program(s) will not be created.
