### PR TITLE
cbBTC/USDC 30,000 USDC on Mainnet

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1136,4 +1136,19 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
+  // cbBTC/USDC 30,000 USDC on Mainnet 10/04/2024 10/18/2024 1pm EST
+  {
+    start: 1728061200n,
+    end: 1729270800n,
+    fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
+    urdAddress: "0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb",
+    tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    marketId: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64",
+    rewardAmount: {
+      supply: parseUnits("7500", 6),
+      borrow: parseUnits("22500", 6),
+      collateral: 0n,
+    },
+    chainId: ChainId.MAINNET,
+  },
 ];


### PR DESCRIPTION
## Context

Add a new market reward program for the cbBTC/USDC market on Mainnet. This program will run from October 4, 2024, to October 18, 2024, at 1pm EST. The reward amount for this program is 30,000 USDC to be split in a 75:25 ratio for the borrow and supply sides respectively.

## Merge conditions checklist

- [ ] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [ ] Send funds to the URD; the PR will only be merged after the funds have been received.

**Important**: If the delay between the PR creation and the start of the Program(s) is less than one week, or if we do not see any funds sent to the URD, the PR will not be merged, and the Program(s) will not be created.
