### PR TITLE
Add uSOL incentives for Universal Vault and uSOL/USDC Market

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1181,10 +1181,10 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
-  // uSOL/USDC 17.5 uSOL on Base 10/14/2024 10/28/2024 5pm GMT
+  // uSOL/USDC 17.5 uSOL on Base 10/15/2024 10/29/2024 5pm GMT
   {
-    start: 1728925200n,
-    end: 1730134800n,
+    start: 1729011600n,
+    end: 1730221200n,
     fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
     urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
     tokenAddress: "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55",

--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1181,4 +1181,19 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
+  // uSOL/USDC 17.5 uSOL on Base 10/14/2024 10/28/2024 5pm GMT
+  {
+    start: 1728925200n,
+    end: 1730134800n,
+    fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
+    urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+    tokenAddress: "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55",
+    marketId: "0xa60e9b888f343351dece4df8251abe5858fc5db96e8624d614a6500c3a3085ea",
+    rewardAmount: {
+      supply: 0n,
+      borrow: parseUnits("17.5", 18),
+      collateral: 0n,
+    },
+    chainId: ChainId.BASE,
+  },
 ];

--- a/src/vault-programs.ts
+++ b/src/vault-programs.ts
@@ -284,4 +284,15 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     amount: parseUnits("60000", 18),
     chainId: ChainId.MAINNET,
   },
+  // Re7 Universal USDC Vault - 17.5 uSOL 10/14-10/28 5pm GMT
+  {
+    start: 1728925200n,
+    end: 1730134800n,
+    fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
+    urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+    tokenAddress: "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55",
+    vault: "0xB7890CEE6CF4792cdCC13489D36D9d42726ab863",
+    amount: parseUnits("17.5", 18),
+    chainId: ChainId.BASE,
+  },
 ];

--- a/src/vault-programs.ts
+++ b/src/vault-programs.ts
@@ -284,10 +284,10 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     amount: parseUnits("60000", 18),
     chainId: ChainId.MAINNET,
   },
-  // Re7 Universal USDC Vault - 17.5 uSOL 10/14-10/28 5pm GMT
+  // Re7 Universal USDC Vault - 17.5 uSOL 10/15-10/29 5pm GMT
   {
-    start: 1728925200n,
-    end: 1730134800n,
+    start: 1729011600n,
+    end: 1730221200n,
     fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
     urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
     tokenAddress: "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55",


### PR DESCRIPTION
## Context

We are incentivizing the newly created [Universal USDC Vault](https://app.morpho.org/vault?vault=0xB7890CEE6CF4792cdCC13489D36D9d42726ab863&network=base) for [Universal Assets](https://app.universalassets.xyz/) and [uSOL/USDC market](https://app.morpho.org/market?id=0xa60e9b888f343351dece4df8251abe5858fc5db96e8624d614a6500c3a3085ea&network=base). 35 uSOL will be distributed as incentives:
- 17.5 uSOL will be distributed towards the Vault.
- 17.5 uSOL will be distributed towards borrowers on the uSOL / USDC market.

## Merge conditions checklist

- [x] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [x] Send funds to the URD; the PR will only be merged after the funds have been received.
- [x] Transaction link(s) for the funds transfer(s) to URD(s): [https://basescan.org/tx/0x5da4a9621e6f59d62930cea7ac1b6e357fc42613858a0acfd71f618175193d24](https://basescan.org/tx/0x5da4a9621e6f59d62930cea7ac1b6e357fc42613858a0acfd71f618175193d24)

