### PR TITLE
Add uSUI and uSOL rewards for Universal Markets and Vault (#70)

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1302,6 +1302,36 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
+  // uSOL/USDC 6.52 uSOL on Base 10/30/2024 11/13/2024 3pm GMT
+  {
+    start: 1730300400n,
+    end: 1731510000n,
+    fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
+    urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+    tokenAddress: "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55",
+    marketId: "0xa60e9b888f343351dece4df8251abe5858fc5db96e8624d614a6500c3a3085ea",
+    rewardAmount: {
+      supply: 0n,
+      borrow: parseUnits("6.5223053386", 18),
+      collateral: 0n,
+    },
+    chainId: ChainId.BASE,
+  },
+  // uSUI/USDC 525.97 uSUI on Base 10/30/2024 11/13/2024 3pm GMT
+  {
+    start: 1730300400n,
+    end: 1731510000n,
+    fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
+    urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+    tokenAddress: "0xb0505e5a99abd03d94a1169e638B78EDfEd26ea4",
+    marketId: "0x5d96564285fc3830f51fe495f88c29cc1232fbca61ca8b6edc25bff921efdef2",
+    rewardAmount: {
+      supply: 0n,
+      borrow: parseUnits("525.9721846763", 18),
+      collateral: 0n,
+    },
+    chainId: ChainId.BASE,
+  },
   // cbBTC/USDC 20,000 USDC on Base 10/28/2024 11/11/2024 1pm EST
   {
     start: 1730134800n,

--- a/src/vault-programs.ts
+++ b/src/vault-programs.ts
@@ -350,4 +350,26 @@ export const vaultPrograms: VaultRewardProgramArgs[] = [
     amount: parseUnits("20000", 18),
     chainId: ChainId.BASE,
   },
+  // Re7 Universal USDC Vault - 6.52 uSOL 10/30-11/13 3pm GMT
+  {
+    start: 1730300400n,
+    end: 1731510000n,
+    fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
+    urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+    tokenAddress: "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55",
+    vault: "0xB7890CEE6CF4792cdCC13489D36D9d42726ab863",
+    amount: parseUnits("6.5223053386", 18),
+    chainId: ChainId.BASE,
+  },
+  // Re7 Universal USDC Vault - 525.97 uSUI 10/30-11/13 3pm GMT
+  {
+    start: 1730300400n,
+    end: 1731510000n,
+    fundsSender: "0x59e7682CcbdB40e4e8B73899a7CF3589026E783B",
+    urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+    tokenAddress: "0xb0505e5a99abd03d94a1169e638B78EDfEd26ea4",
+    vault: "0xB7890CEE6CF4792cdCC13489D36D9d42726ab863",
+    amount: parseUnits("525.9721846763", 18),
+    chainId: ChainId.BASE,
+  },
 ];


### PR DESCRIPTION
## Context

After the previous Universal's [uSOL campaign](https://github.com/morpho-org/morpho-blue-reward-programs/pull/59) we have decided to do another campaign to incentivize Universal's USDC Vault as well as uSOL and the newly launched uSUI market. The distribution will be as follows:
- 13.04 uSOL
  - 50% will go towards borrowing on uSOL/USDC market.
  - 50% will go towards Universal's USDC Vault.
- 1,051.94 uSUI
  - 50% will go towards borrowing on uSUI/USDC market.
  - 50% will go towards Universal's USDC Vault.

## Merge conditions checklist

- [x] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [x] Send funds to the URD; the PR will only be merged after the funds have been received.
- [x] Transaction link(s) for the funds transfer(s) to URD(s):
  - [uSOL](https://basescan.org/tx/0x378bc5b9e3a76ee6dfea520c610547b12f6a5c80cb1dc4127329414df1852774)
  - [uSUI](https://basescan.org/tx/0x899480d44c2a03b491041997262ad0437067027b223450c8cf96e979858a0434)
