### PR TITLE
25K to cbBTC/USDC on Base

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1377,4 +1377,19 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.MAINNET,
   },
+  // cbBTC/USDC 25,000 USDC on Base 11/06/2024 11/???/2024 1pm EST
+  {
+    start: 1730916000n,
+    end: 1733508000n,
+    fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
+    urdAddress: "0x5400dBb270c956E8985184335A1C62AcA6Ce1333",
+    tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    marketId: "0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836",
+    rewardAmount: {
+      supply: parseUnits("0", 6),
+      borrow: parseUnits("25000", 6),
+      collateral: 0n,
+    },
+    chainId: ChainId.BASE,
+  },
 ];


### PR DESCRIPTION
## Context
Add a new market reward programs for the cbBTC/USDC on Base. This program will run from Nov 6, 2024, to December 6, 2024, 1pm EST. The reward amount for this program is 25,000 USDC to be allocated entirely to the borrow side.



Please, provide here any context that could help us to validate the Reward Program(s).

## Merge conditions checklist

- [ ] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [ ] Send funds to the URD; the PR will only be merged after the funds have been received.
- [ ] Transaction link(s) for the funds transfer(s) to URD(s): [*Insert tx link here*]

**Important**: If the delay between the PR creation and the start of the Program(s) is less than one week, or if we do not see any funds sent to the URD, the PR will not be merged, and the Program(s) will not be created.
