### PR TITLE
sUSDS on base week 2 program

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1750,5 +1750,35 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
       collateral: 0n,
     },
     chainId: ChainId.BASE,
-  },
+  },  
+  // wstETH/sUSDS 12,500 USDS on Base 3/17/2025 03/24/2025 0am UTC
+  {
+     start: 1742169600n,
+     end: 1742774400n,
+     fundsSender: "0x1Fe9F102593861118D8664E84201ec9754198F30",
+     urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+     tokenAddress: "0x820C137fa70C8691f0e44Dc420a5e53c168921Dc",
+     marketId: "0xb003f1eddcaece702f8b34d684840ef913e00d6c9b0e209f67f8524bfc095733",
+     rewardAmount: {
+       supply: parseUnits("12500", 18),
+       borrow: 0n,
+       collateral: 0n,
+     },
+     chainId: ChainId.BASE,
+   },
+   // cbBTC/sUSDS 12,500 USDS on Base 3/17/2025 03/24/2025 0am UTC
+   {
+     start: 1742169600n,
+     end: 1742774400n,
+     fundsSender: "0x1Fe9F102593861118D8664E84201ec9754198F30",
+     urdAddress: "0x5400dbb270c956e8985184335a1c62aca6ce1333",
+     tokenAddress: "0x820C137fa70C8691f0e44Dc420a5e53c168921Dc",
+     marketId: "0x680f4dfd7af2baa95465a72773e1865612ee0222808a7f8acca6becd70d1be45",
+     rewardAmount: {
+       supply: parseUnits("12500", 18),
+       borrow: 0n,
+       collateral: 0n,
+     },
+     chainId: ChainId.BASE,
+   },
 ];


### PR DESCRIPTION
## Context

sUSDS on base week 2 program in coordination with Sky and Theo. Sky send us payment on Monday each week and we relay to the URD.

Target is to rewards 25k USDS per week on cbBTC/sUSDS and wstETH/sUSDS supply (50-50 split).

## Merge conditions checklist

- [X] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [X] Send funds to the URD; the PR will only be merged after the funds have been received.
- [X] Transaction link(s) for the funds transfer(s) to URD(s): https://basescan.org/tx/0x9ece8818db39189bc7cc61c43632032e1566012d0926b43ccf963173b11bfd66