### PR TITLE
Incentivizing 2 new EURC markets on Base

### DIFF
--- a/src/market-programs.ts
+++ b/src/market-programs.ts
@@ -1871,4 +1871,34 @@ export const marketPrograms: MarketRewardProgramArgs[] = [
     },
     chainId: ChainId.BASE,
   },
+  // cbBTC/EURC 2000 EURC 04/14/2025 04/28/2025 1pm EST
+  {
+    start: 1744668000n,
+    end: 1745877600n,
+    fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
+    urdAddress: "0x5400dBb270c956E8985184335A1C62AcA6Ce1333",
+    tokenAddress: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
+    marketId: "0x67ebd84b2fb39e3bc5a13d97e4c07abe1ea617e40654826e9abce252e95f049e",
+    rewardAmount: {
+      supply: 0n,
+      borrow: parseUnits("2000", 6),
+      collateral: 0n,
+    },
+    chainId: ChainId.BASE,
+  },
+  // cbETH/EURC 1000 EURC 04/14/2025 04/28/2025 1pm EST
+  {
+    start: 1744668000n,
+    end: 1745877600n,
+    fundsSender: "0x874A0A0fc772a32b40e3749ACc3B72f3b0c9b82a",
+    urdAddress: "0x5400dBb270c956E8985184335A1C62AcA6Ce1333",
+    tokenAddress: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
+    marketId: "0x7fc498ddcb7707d6f85f6dc81f61edb6dc8d7f1b47a83b55808904790564929a",
+    rewardAmount: {
+      supply: 0n,
+      borrow: parseUnits("1000", 6),
+      collateral: 0n,
+    },
+    chainId: ChainId.BASE,
+  },
 ];


### PR DESCRIPTION
## Context
Add 2 new market reward programs for the cbBTC/EURC and cbETH/EURC markets on Base. This program will run from April 14, 2025, to April 28, 2025, 1pm EST. The reward amount for this program is 2K EURC for cbBTC/EURC and 1K EURC for cbETH/EURC to be allocated entirely to the borrow side.

## Merge conditions checklist

- [ ] Ensure there is at least one week between the PR submission and the start of the Program(s).
- [ ] Send funds to the URD; the PR will only be merged after the funds have been received.
- [ ] Transaction link(s) for the funds transfer(s) to URD(s): [*Insert tx link here*]

**Important**: If the delay between the PR creation and the start of the Program(s) is less than one week, or if we do not see any funds sent to the URD, the PR will not be merged, and the Program(s) will not be created.
